### PR TITLE
Add Residential Wiring section with NEC load calculator and ampacity charts

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,6 +3,7 @@ import HomeScreen from './src/screens/HomeScreen';
 import OhmsLawScreen from './src/screens/OhmsLawScreen';
 import AmperesLawScreen from './src/screens/AmperesLawScreen';
 import VoltageDividerScreen from './src/screens/VoltageDividerScreen';
+import ResidentialWiringScreen from './src/screens/ResidentialWiringScreen';
 
 export default function App() {
   const [screen, setScreen] = useState('home');
@@ -15,6 +16,9 @@ export default function App() {
   }
   if (screen === 'divider') {
     return <VoltageDividerScreen onBack={() => setScreen('home')} />;
+  }
+  if (screen === 'residential') {
+    return <ResidentialWiringScreen onBack={() => setScreen('home')} />;
   }
   return <HomeScreen onNavigate={setScreen} />;
 }

--- a/src/data/ampacityCharts.js
+++ b/src/data/ampacityCharts.js
@@ -1,0 +1,34 @@
+// NEC Table 310.16 — Allowable Ampacities of Insulated Conductors
+// Rated up to 2000 Volts, 60°C Through 90°C
+// Not More Than 3 Current-Carrying Conductors in Raceway, Cable, or Earth
+
+export const copperAmpacity = [
+  { awg: '14', temp60: 15, temp75: 20, temp90: 25 },
+  { awg: '12', temp60: 20, temp75: 25, temp90: 30 },
+  { awg: '10', temp60: 30, temp75: 35, temp90: 40 },
+  { awg: '8', temp60: 40, temp75: 50, temp90: 55 },
+  { awg: '6', temp60: 55, temp75: 65, temp90: 75 },
+  { awg: '4', temp60: 70, temp75: 85, temp90: 95 },
+  { awg: '3', temp60: 85, temp75: 100, temp90: 115 },
+  { awg: '2', temp60: 95, temp75: 115, temp90: 130 },
+  { awg: '1', temp60: 110, temp75: 130, temp90: 145 },
+  { awg: '1/0', temp60: 125, temp75: 150, temp90: 170 },
+  { awg: '2/0', temp60: 145, temp75: 175, temp90: 195 },
+  { awg: '3/0', temp60: 165, temp75: 200, temp90: 225 },
+  { awg: '4/0', temp60: 195, temp75: 230, temp90: 260 },
+];
+
+export const aluminumAmpacity = [
+  { awg: '12', temp60: 15, temp75: 20, temp90: 25 },
+  { awg: '10', temp60: 25, temp75: 30, temp90: 35 },
+  { awg: '8', temp60: 30, temp75: 40, temp90: 45 },
+  { awg: '6', temp60: 40, temp75: 50, temp90: 60 },
+  { awg: '4', temp60: 55, temp75: 65, temp90: 75 },
+  { awg: '3', temp60: 65, temp75: 75, temp90: 85 },
+  { awg: '2', temp60: 75, temp75: 90, temp90: 100 },
+  { awg: '1', temp60: 85, temp75: 100, temp90: 115 },
+  { awg: '1/0', temp60: 100, temp75: 120, temp90: 135 },
+  { awg: '2/0', temp60: 115, temp75: 135, temp90: 150 },
+  { awg: '3/0', temp60: 130, temp75: 155, temp90: 175 },
+  { awg: '4/0', temp60: 150, temp75: 180, temp90: 205 },
+];

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -26,6 +26,14 @@ const CALCULATORS = [
     color: '#00796B',
     icon: 'V',
   },
+  {
+    key: 'residential',
+    title: 'Residential Wiring',
+    subtitle: 'NEC Article 220 & Table 310.16',
+    description: 'Load calculations & wire ampacity charts',
+    color: '#E65100',
+    icon: 'W',
+  },
 ];
 
 export default function HomeScreen({ onNavigate }) {

--- a/src/screens/ResidentialWiringScreen.js
+++ b/src/screens/ResidentialWiringScreen.js
@@ -1,0 +1,336 @@
+import { useState, useMemo } from 'react';
+import {
+  Keyboard,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import InputField from '../components/InputField';
+import { calculateResidentialLoad } from '../utils/necCalculations';
+import { copperAmpacity, aluminumAmpacity } from '../data/ampacityCharts';
+
+const TEMP_LABELS = {
+  temp60: '60°C',
+  temp75: '75°C',
+  temp90: '90°C',
+};
+
+export default function ResidentialWiringScreen({ onBack }) {
+  const [sqft, setSqft] = useState('');
+  const [smallApplianceCircuits, setSmallApplianceCircuits] = useState('2');
+  const [fixedApplianceVA, setFixedApplianceVA] = useState('');
+  const [showAluminum, setShowAluminum] = useState(false);
+
+  const calculatedLoad = useMemo(() => {
+    const squareFeet = parseFloat(sqft) || 0;
+    const circuits = parseInt(smallApplianceCircuits, 10) || 2;
+    const applianceVA = parseFloat(fixedApplianceVA) || 0;
+    return calculateResidentialLoad({
+      squareFeet,
+      smallApplianceCircuits: circuits,
+      fixedApplianceVA: applianceVA,
+    });
+  }, [sqft, smallApplianceCircuits, fixedApplianceVA]);
+
+  const handleReset = () => {
+    Keyboard.dismiss();
+    setSqft('');
+    setSmallApplianceCircuits('2');
+    setFixedApplianceVA('');
+  };
+
+  const ampacityData = showAluminum ? aluminumAmpacity : copperAmpacity;
+
+  return (
+    <View style={styles.screen}>
+      <StatusBar style="light" />
+      <View style={styles.header}>
+        <View style={styles.headerTop}>
+          {onBack && (
+            <TouchableOpacity onPress={onBack} style={styles.backButton} activeOpacity={0.7}>
+              <Text style={styles.backText}>{'<'} Back</Text>
+            </TouchableOpacity>
+          )}
+          <View style={styles.headerTitleWrap}>
+            <Text style={styles.headerTitle}>Residential Wiring</Text>
+            <Text style={styles.headerSubtitle}>NEC Article 220 & Table 310.16</Text>
+          </View>
+        </View>
+      </View>
+
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Load Calculator Card */}
+          <View style={styles.card}>
+            <Text style={styles.sectionTitle}>Residential Load Calculator</Text>
+            <Text style={styles.instructions}>
+              Calculate service load per NEC Article 220 standard method
+            </Text>
+
+            <InputField
+              label="Dwelling Area"
+              unit="sq ft"
+              value={sqft}
+              onChangeText={setSqft}
+            />
+
+            <InputField
+              label="Small Appliance Circuits"
+              unit="min 2 (NEC)"
+              value={smallApplianceCircuits}
+              onChangeText={setSmallApplianceCircuits}
+            />
+
+            <InputField
+              label="Fixed Appliance Load"
+              unit="VA"
+              value={fixedApplianceVA}
+              onChangeText={setFixedApplianceVA}
+            />
+
+            <TouchableOpacity
+              style={styles.resetButton}
+              onPress={handleReset}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.resetButtonText}>Reset</Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Results Card */}
+          <View style={styles.card}>
+            <Text style={styles.sectionTitle}>Calculation Breakdown</Text>
+
+            <View style={styles.resultRow}>
+              <Text style={styles.resultLabel}>General Lighting (3 VA/sq ft)</Text>
+              <Text style={styles.resultValue}>{calculatedLoad.generalLightingLoad} VA</Text>
+            </View>
+            <View style={styles.resultRow}>
+              <Text style={styles.resultLabel}>Small Appliance Circuits</Text>
+              <Text style={styles.resultValue}>{calculatedLoad.smallApplianceLoad} VA</Text>
+            </View>
+            <View style={styles.resultRow}>
+              <Text style={styles.resultLabel}>Laundry Circuit</Text>
+              <Text style={styles.resultValue}>{calculatedLoad.laundryLoad} VA</Text>
+            </View>
+            <View style={styles.divider} />
+            <View style={styles.resultRow}>
+              <Text style={styles.resultLabel}>Total Connected Load</Text>
+              <Text style={styles.resultValue}>{calculatedLoad.totalConnectedLoad} VA</Text>
+            </View>
+            <View style={styles.resultRow}>
+              <Text style={styles.resultLabel}>After Demand Factors</Text>
+              <Text style={styles.resultValue}>{calculatedLoad.netLoad} VA</Text>
+            </View>
+            <View style={styles.resultRow}>
+              <Text style={styles.resultLabel}>+ Fixed Appliances</Text>
+              <Text style={styles.resultValue}>{calculatedLoad.totalLoadVA} VA</Text>
+            </View>
+            <View style={styles.divider} />
+            <View style={styles.resultRowHighlight}>
+              <Text style={styles.resultLabelBold}>Minimum Service Size</Text>
+              <Text style={styles.resultValueBold}>{calculatedLoad.serviceAmps} A</Text>
+            </View>
+          </View>
+
+          {/* Ampacity Chart Card */}
+          <View style={styles.card}>
+            <Text style={styles.sectionTitle}>
+              Wire Ampacity Chart (NEC 310.16)
+            </Text>
+
+            <View style={styles.toggleRow}>
+              <TouchableOpacity
+                style={[styles.toggleButton, !showAluminum && styles.toggleActive]}
+                onPress={() => setShowAluminum(false)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.toggleText, !showAluminum && styles.toggleTextActive]}>
+                  Copper
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.toggleButton, showAluminum && styles.toggleActive]}
+                onPress={() => setShowAluminum(true)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.toggleText, showAluminum && styles.toggleTextActive]}>
+                  Aluminum
+                </Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* Table Header */}
+            <View style={styles.tableHeader}>
+              <Text style={[styles.tableHeaderCell, styles.awgCell]}>AWG</Text>
+              <Text style={styles.tableHeaderCell}>{TEMP_LABELS.temp60}</Text>
+              <Text style={styles.tableHeaderCell}>{TEMP_LABELS.temp75}</Text>
+              <Text style={styles.tableHeaderCell}>{TEMP_LABELS.temp90}</Text>
+            </View>
+
+            {/* Table Rows */}
+            {ampacityData.map((row, index) => (
+              <View
+                key={row.awg}
+                style={[styles.tableRow, index % 2 === 0 && styles.tableRowEven]}
+              >
+                <Text style={[styles.tableCell, styles.awgCell, styles.awgText]}>
+                  {row.awg}
+                </Text>
+                <Text style={styles.tableCell}>{row.temp60} A</Text>
+                <Text style={styles.tableCell}>{row.temp75} A</Text>
+                <Text style={styles.tableCell}>{row.temp90} A</Text>
+              </View>
+            ))}
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: '#F5F5F5' },
+  flex: { flex: 1 },
+  header: {
+    backgroundColor: '#E65100',
+    paddingTop: 54,
+    paddingBottom: 20,
+    paddingHorizontal: 20,
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    elevation: 8,
+  },
+  headerTop: { flexDirection: 'row', alignItems: 'flex-start' },
+  backButton: { marginRight: 12, paddingTop: 4 },
+  backText: { color: 'rgba(255,255,255,0.9)', fontSize: 16, fontWeight: '600' },
+  headerTitleWrap: { flex: 1 },
+  headerTitle: { fontSize: 28, fontWeight: '800', color: '#fff' },
+  headerSubtitle: { fontSize: 16, color: 'rgba(255,255,255,0.8)', marginTop: 4 },
+  scrollContent: { padding: 16, paddingBottom: 40 },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#333',
+    marginBottom: 6,
+  },
+  instructions: { fontSize: 14, color: '#777', marginBottom: 18 },
+
+  // Reset button
+  resetButton: {
+    backgroundColor: '#fff',
+    paddingVertical: 15,
+    borderRadius: 12,
+    alignItems: 'center',
+    borderWidth: 1.5,
+    borderColor: '#E0E0E0',
+    marginTop: 6,
+  },
+  resetButtonText: { color: '#666', fontSize: 18, fontWeight: '600' },
+
+  // Results
+  resultRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 8,
+  },
+  resultLabel: { fontSize: 14, color: '#555', flex: 1 },
+  resultValue: { fontSize: 14, color: '#333', fontWeight: '600' },
+  resultRowHighlight: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 10,
+    backgroundColor: '#E8F5E9',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+  },
+  resultLabelBold: { fontSize: 16, color: '#2E7D32', fontWeight: '700' },
+  resultValueBold: { fontSize: 16, color: '#2E7D32', fontWeight: '800' },
+  divider: {
+    height: 1,
+    backgroundColor: '#E0E0E0',
+    marginVertical: 4,
+  },
+
+  // Copper/Aluminum toggle
+  toggleRow: {
+    flexDirection: 'row',
+    marginBottom: 14,
+    gap: 8,
+  },
+  toggleButton: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: 'center',
+    backgroundColor: '#F5F5F5',
+    borderWidth: 1.5,
+    borderColor: '#E0E0E0',
+  },
+  toggleActive: {
+    backgroundColor: '#E65100',
+    borderColor: '#E65100',
+  },
+  toggleText: { fontSize: 15, fontWeight: '600', color: '#666' },
+  toggleTextActive: { color: '#fff' },
+
+  // Table
+  tableHeader: {
+    flexDirection: 'row',
+    backgroundColor: '#424242',
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 4,
+    marginBottom: 2,
+  },
+  tableHeaderCell: {
+    flex: 1,
+    textAlign: 'center',
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  tableRow: {
+    flexDirection: 'row',
+    paddingVertical: 10,
+    paddingHorizontal: 4,
+    borderRadius: 4,
+  },
+  tableRowEven: {
+    backgroundColor: '#FAFAFA',
+  },
+  tableCell: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 14,
+    color: '#444',
+  },
+  awgCell: { flex: 0.8 },
+  awgText: { fontWeight: '700', color: '#333' },
+});

--- a/src/utils/necCalculations.js
+++ b/src/utils/necCalculations.js
@@ -1,0 +1,54 @@
+/**
+ * Calculates the total service load for a residential dwelling
+ * based on the NEC Article 220 standard method.
+ *
+ * @param {object} inputs - The user-provided values.
+ * @param {number} inputs.squareFeet - Total floor area.
+ * @param {number} inputs.smallApplianceCircuits - Number of small appliance circuits.
+ * @param {boolean} inputs.laundryCircuit - Whether a laundry circuit is present.
+ * @param {number} inputs.fixedApplianceVA - Sum of VA ratings for fixed appliances.
+ * @returns {object} An object containing the calculated loads and total service amperage.
+ */
+export function calculateResidentialLoad({
+  squareFeet = 0,
+  smallApplianceCircuits = 2,
+  laundryCircuit = true,
+  fixedApplianceVA = 0,
+}) {
+  const LIGHTING_VA_PER_SQ_FT = 3;
+  const SMALL_APPLIANCE_VA = 1500;
+  const LAUNDRY_VA = 1500;
+  const SERVICE_VOLTAGE = 240;
+
+  // 1. General Lighting & Receptacle Load
+  const generalLightingLoad = squareFeet * LIGHTING_VA_PER_SQ_FT;
+
+  // 2. Small Appliance & Laundry Load
+  const smallApplianceLoad = smallApplianceCircuits * SMALL_APPLIANCE_VA;
+  const laundryLoad = laundryCircuit ? LAUNDRY_VA : 0;
+  const totalConnectedLoad = generalLightingLoad + smallApplianceLoad + laundryLoad;
+
+  // 3. Apply Demand Factors (NEC 220.42)
+  let netLoad;
+  if (totalConnectedLoad <= 3000) {
+    netLoad = totalConnectedLoad;
+  } else {
+    netLoad = 3000 + (totalConnectedLoad - 3000) * 0.35;
+  }
+
+  // 4. Add Fixed Appliances
+  const totalLoadVA = netLoad + fixedApplianceVA;
+
+  // 5. Calculate Total Service Amperage
+  const serviceAmps = totalLoadVA / SERVICE_VOLTAGE;
+
+  return {
+    generalLightingLoad: parseFloat(generalLightingLoad.toFixed(2)),
+    smallApplianceLoad: parseFloat(smallApplianceLoad.toFixed(2)),
+    laundryLoad: parseFloat(laundryLoad.toFixed(2)),
+    totalConnectedLoad: parseFloat(totalConnectedLoad.toFixed(2)),
+    netLoad: parseFloat(netLoad.toFixed(2)),
+    totalLoadVA: parseFloat(totalLoadVA.toFixed(2)),
+    serviceAmps: parseFloat(serviceAmps.toFixed(2)),
+  };
+}

--- a/tests/necCalculations.test.js
+++ b/tests/necCalculations.test.js
@@ -1,0 +1,125 @@
+const { calculateResidentialLoad } = require('../src/utils/necCalculations');
+
+describe('Residential Load Calculator (NEC Article 220)', () => {
+  // ── Default values ────────────────────────────────────────────────────────
+
+  describe('default inputs', () => {
+    test('zero square feet with defaults returns base small-appliance + laundry load', () => {
+      const r = calculateResidentialLoad({ squareFeet: 0 });
+      // 2 circuits * 1500 = 3000 + 1500 laundry = 4500 total connected
+      // Demand: 3000 + (4500 - 3000) * 0.35 = 3000 + 525 = 3525
+      expect(r.generalLightingLoad).toBe(0);
+      expect(r.smallApplianceLoad).toBe(3000);
+      expect(r.laundryLoad).toBe(1500);
+      expect(r.totalConnectedLoad).toBe(4500);
+      expect(r.netLoad).toBe(3525);
+      expect(r.totalLoadVA).toBe(3525);
+      expect(r.serviceAmps).toBeCloseTo(14.69, 2);
+    });
+  });
+
+  // ── Demand factor application ─────────────────────────────────────────────
+
+  describe('demand factor thresholds', () => {
+    test('total connected load at exactly 3000 VA uses 100% demand', () => {
+      // Need: lighting + small appliance + laundry = 3000
+      // 2 circuits = 3000, laundry = 1500 → that's 4500. Too much.
+      // Use 0 sqft, 1 circuit, no laundry → 1500 VA (under 3000)
+      const r = calculateResidentialLoad({
+        squareFeet: 0,
+        smallApplianceCircuits: 2,
+        laundryCircuit: false,
+      });
+      // 0 + 3000 + 0 = 3000 → exactly at threshold
+      expect(r.totalConnectedLoad).toBe(3000);
+      expect(r.netLoad).toBe(3000);
+    });
+
+    test('total connected load above 3000 VA applies 35% demand on excess', () => {
+      const r = calculateResidentialLoad({
+        squareFeet: 1000,
+        smallApplianceCircuits: 2,
+        laundryCircuit: true,
+      });
+      // Lighting: 1000 * 3 = 3000
+      // Small appliance: 2 * 1500 = 3000
+      // Laundry: 1500
+      // Total: 7500
+      // Demand: 3000 + (7500 - 3000) * 0.35 = 3000 + 1575 = 4575
+      expect(r.totalConnectedLoad).toBe(7500);
+      expect(r.netLoad).toBe(4575);
+    });
+  });
+
+  // ── Lighting load ─────────────────────────────────────────────────────────
+
+  describe('general lighting load', () => {
+    test('calculates at 3 VA per square foot', () => {
+      const r = calculateResidentialLoad({ squareFeet: 2000 });
+      expect(r.generalLightingLoad).toBe(6000);
+    });
+  });
+
+  // ── Small appliance circuits ──────────────────────────────────────────────
+
+  describe('small appliance circuits', () => {
+    test('each circuit adds 1500 VA', () => {
+      const r3 = calculateResidentialLoad({ squareFeet: 0, smallApplianceCircuits: 3 });
+      expect(r3.smallApplianceLoad).toBe(4500);
+    });
+  });
+
+  // ── Laundry circuit ───────────────────────────────────────────────────────
+
+  describe('laundry circuit', () => {
+    test('laundry circuit adds 1500 VA when true', () => {
+      const r = calculateResidentialLoad({ squareFeet: 0, laundryCircuit: true });
+      expect(r.laundryLoad).toBe(1500);
+    });
+
+    test('laundry circuit adds 0 VA when false', () => {
+      const r = calculateResidentialLoad({ squareFeet: 0, laundryCircuit: false });
+      expect(r.laundryLoad).toBe(0);
+    });
+  });
+
+  // ── Fixed appliance load ──────────────────────────────────────────────────
+
+  describe('fixed appliance load', () => {
+    test('fixed appliance VA is added after demand factors', () => {
+      const withoutAppliances = calculateResidentialLoad({ squareFeet: 1500 });
+      const withAppliances = calculateResidentialLoad({
+        squareFeet: 1500,
+        fixedApplianceVA: 5000,
+      });
+      expect(withAppliances.totalLoadVA).toBe(withoutAppliances.netLoad + 5000);
+    });
+  });
+
+  // ── Service amperage ──────────────────────────────────────────────────────
+
+  describe('service amperage', () => {
+    test('service amps is total load divided by 240V', () => {
+      const r = calculateResidentialLoad({
+        squareFeet: 1500,
+        fixedApplianceVA: 10000,
+      });
+      expect(r.serviceAmps).toBeCloseTo(r.totalLoadVA / 240, 2);
+    });
+
+    test('typical 2000 sq ft home calculation', () => {
+      const r = calculateResidentialLoad({
+        squareFeet: 2000,
+        smallApplianceCircuits: 2,
+        laundryCircuit: true,
+        fixedApplianceVA: 12000,
+      });
+      // Lighting: 6000, SA: 3000, Laundry: 1500 → 10500
+      // Demand: 3000 + (10500 - 3000) * 0.35 = 3000 + 2625 = 5625
+      // + Fixed: 5625 + 12000 = 17625
+      // Amps: 17625 / 240 = 73.4375
+      expect(r.totalLoadVA).toBe(17625);
+      expect(r.serviceAmps).toBeCloseTo(73.44, 2);
+    });
+  });
+});


### PR DESCRIPTION
Implement a new Residential Wiring feature with:
- NEC Article 220 standard method residential load calculator
- Interactive copper/aluminum wire ampacity chart (NEC Table 310.16)
- New screen with input fields, live calculation breakdown, and toggle between conductor types
- Navigation card on HomeScreen and routing in App.js
- Comprehensive test suite for NEC calculation logic

https://claude.ai/code/session_01DS7pjoGtCnzMK4NwEYBXXu